### PR TITLE
feat: add triton-python-model library in conda environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @xiaofei-du @pinglin @Phelan164

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[contact@instill.tech](contact@instill.tech).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing Guidelines
+
+Hello! Thanks for your interest in contributing to the codebase.
+
+## How to contribute
+
+TBD
+
+
+## Submitting a pull request
+
+To make an efficient review process, we very much appreciate if the PR commits
+
+- follow the [conventional commits guidelines](https://www.conventionalcommits.org/),
+- follow the [7 rules of commit messages](https://chris.beams.io/posts/git-commit/), and
+- are rearranged to squash trivial commits together (use [git rebase](http://gitready.com/advanced/2009/03/20/reorder-commits-with-rebase.html)).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Because
+
+- (write the reason why we need to consider this PR in a list)
+
+This commit
+
+- (write the summary of all commits in this PR in a list)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+If you discover a security issue in this repository, please contact us through security@instill.tech.
+
+Thanks for helping make the codebase safe for everyone.

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,6 +26,7 @@ jobs:
           push: true
           file: Dockerfile.cpu
           tags: instill/triton-conda-env:${{ github.ref_name }}-cpu
+          build-args: TRITON_PYTHON_MODEL_VERSION=${{ github.ref_name }}
           cache-from: type=registry,ref=instill/triton-conda-env:buildcache-cpu
           cache-to: type=registry,ref=instill/triton-conda-env:buildcache-cpu,mode=max
       - name: Build and push GPU image
@@ -35,5 +36,6 @@ jobs:
           push: true
           file: Dockerfile.gpu
           tags: instill/triton-conda-env:latest,instill/triton-conda-env:${{ github.ref_name }}-gpu
+          build-args: TRITON_PYTHON_MODEL_VERSION=${{ github.ref_name }}
           cache-from: type=registry,ref=instill/triton-conda-env:buildcache-gpu
           cache-to: type=registry,ref=instill/triton-conda-env:buildcache-gpu,mode=max

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,17 +17,24 @@ jobs:
         id: release
         with:
           token: ${{ secrets.botGitHubToken }}
-          release-type: go
+          release-type: python
           command: manifest
           config-file: release-please/config.json
           manifest-file: release-please/manifest.json
       - uses: actions/checkout@v2
-      - name: tag major and minor versions
+        with:
+          token: ${{ secrets.botGitHubToken }}
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.botGPGPrivateKey }}
+          passphrase: ${{ secrets.botGPGPassphrase }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      - name: Tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |
-          git config user.name droplet-bot
-          git config user.email droplet-bot@instill.tech
-          git remote add gh-token "https://${{ secrets.botGitHubToken }}@github.com/instill-ai/vdp.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,102 @@
+# From https://github.com/github/gitignore
+
+#### Visual Studio Code
+.vscode
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+#### Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Cython debug symbols
+cython_debug/
+
+# Auto-gen files
+autogen
+
+# mysql persistent data
+mysql-persistence/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+/openapi
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,6 +1,18 @@
 FROM continuumio/miniconda3 AS build
 
-RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch torchvision cpuonly -c conda-forge -c pytorch
+ARG PYTHONNOUSERSITE=True
+
+RUN conda create --name triton-conda-env python=3.8 scikit-learn pillow pytorch torchvision cpuonly -c conda-forge -c pytorch
+
+# Instill triton-python-model
+ARG TRITON_PYTHON_MODEL_VERSION
+ADD /triton_python_model /tmp/triton_python_model
+ADD requirements.txt /tmp/
+ADD setup.py /tmp/
+RUN conda run -n triton-conda-env \
+  python -m pip install -r /tmp/requirements.txt
+RUN conda run -n triton-conda-env \
+  python -m pip install --no-deps /tmp
 
 # Install conda-pack
 RUN conda install conda-pack

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -5,7 +5,7 @@ ARG PYTHONNOUSERSITE=True
 RUN conda create --name triton-conda-env python=3.8 scikit-learn pillow pytorch torchvision cpuonly -c conda-forge -c pytorch
 
 # Instill triton-python-model
-ARG TRITON_PYTHON_MODEL_VERSION
+ARG TRITON_PYTHON_MODEL_VERSION=dev
 ADD /triton_python_model /tmp/triton_python_model
 ADD requirements.txt /tmp/
 ADD setup.py /tmp/

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,6 +1,18 @@
 FROM continuumio/miniconda3 AS build
 
-RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch torchvision -c conda-forge -c pytorch
+ARG PYTHONNOUSERSITE=True
+
+RUN conda create --name triton-conda-env python=3.8 scikit-learn pillow pytorch torchvision -c conda-forge -c pytorch
+
+# Instill triton-python-model
+ARG TRITON_PYTHON_MODEL_VERSION
+ADD /triton_python_model /tmp/triton_python_model
+ADD requirements.txt /tmp/
+ADD setup.py /tmp/
+RUN conda run -n triton-conda-env \
+  python -m pip install -r /tmp/requirements.txt
+RUN conda run -n triton-conda-env \
+  python -m pip install --no-deps /tmp
 
 # Install conda-pack
 RUN conda install conda-pack

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -5,7 +5,7 @@ ARG PYTHONNOUSERSITE=True
 RUN conda create --name triton-conda-env python=3.8 scikit-learn pillow pytorch torchvision -c conda-forge -c pytorch
 
 # Instill triton-python-model
-ARG TRITON_PYTHON_MODEL_VERSION
+ARG TRITON_PYTHON_MODEL_VERSION=dev
 ADD /triton_python_model /tmp/triton_python_model
 ADD requirements.txt /tmp/
 ADD setup.py /tmp/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-# triton-conda-env
+# Triton Python model
+The goal of Triton Python model package `triton-python-model` is to streamline Python model serving in [Visual Data Processing (VDP) project](https://github.com/instill-ai/vdp).
 
-This repository is for maintaining Dockerfiles for Instill AI's official Conda environment for Triton python-backend.
+## Use custom python execution environments in Triton
+From [Triton python backend](https://github.com/triton-inference-server/python_backend/tree/main#using-custom-python-execution-environments) guideline:
+
+> Python backend uses a stub process to connect your model.py file to the Triton C++ core. This stub process has an embedded Python interpreter with a fixed Python version.
+
+We maintain Dockerfiles for Instill AI's official [conda](https://docs.conda.io/en/latest/) environment for Triton python-backend. In the conda environment, we use Python 3.8 and install packages
+- [scikit-learn](https://github.com/scikit-learn/scikit-learn)
+- [Pillow](https://github.com/python-pillow/Pillow)
+- [PyTorch](https://github.com/pytorch/pytorch)
+- triton-python-model
+
+## License
+
+See the [LICENSE](https://github.com/instill-ai/triton-python-model/blob/main/LICENSE) file for licensing information.

--- a/release-please/config.json
+++ b/release-please/config.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     ".": {
-      "release-type": "go",
+      "release-type": "python",
       "draft": false,
       "prerelease": true,
       "bump-minor-pre-major": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.21.2
+packaging>=21.3
+setuptools>=58.0.4

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,74 @@
+import os
+import setuptools
+from pathlib import Path
+from packaging import version
+
+
+# --- Compute the version
+NAME = "triton-python-model"
+VERSION = os.environ.get("TRITON_PYTHON_MODEL_VERSION")
+assert VERSION is not None, "Set env variable TRITON_PYTHON_MODEL_VERSION as the package version"
+if VERSION is not None:
+    assert VERSION[0] == "v", "Env variable TRITON_PYTHON_MODEL_VERSION should start with 'v' and use vX.Y.Z syntax"
+    VERSION = VERSION[1:]
+try:
+    version.Version(VERSION)  # assert if regex fails
+except version.InvalidVersion as err:
+    print(
+        str(err) + f"\nVersion must match the regex: {version.VERSION_PATTERN}")
+
+
+def set_version_in_file(version="HEAD"):
+    ini_file_path = Path(__file__).parent / \
+        "triton_python_model" / "__init__.py"
+    ini_file_lines = list(open(ini_file_path))
+    with open(ini_file_path, "w") as f:
+        for line in ini_file_lines:
+            if line.startswith("__version__"):
+                f.write("__version__ = \"{}\"\n".format(version))
+            else:
+                f.write(line)
+
+
+# -- Auto-update the build version in the library
+set_version_in_file(VERSION)
+
+# --- Cache readme into a string
+README = ""
+if Path("README.md").exists():
+    with open("README.md", "r", encoding="utf-8") as fh:
+        README = fh.read()
+
+# -- Extract dependencies
+REQS = [line.strip() for line in open("requirements.txt")]
+INSTALL_PACKAGES = [line for line in REQS if not line.startswith("#")]
+
+# -- Build the whl file
+setuptools.setup(
+    name=NAME,
+    version=VERSION,
+    description="A python package to streamline python model serving in Visual Data Processing (VDP) project",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    author="Instill AI",
+    author_email="support@instill.tech",
+    license="Apache 2.0",
+    install_requires=INSTALL_PACKAGES,
+    url="https://github.com/instill-ai/trition-python-model",
+    packages=setuptools.find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Scientific/Engineering :: Image Processing",
+        "Topic :: Scientific/Engineering :: Image Recognition",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    python_requires='>=3.8',
+)
+
+# --- Revert the version in the source file
+set_version_in_file("HEAD")

--- a/triton_python_model/__init__.py
+++ b/triton_python_model/__init__.py
@@ -1,0 +1,8 @@
+"""Root of the module."""
+
+# --- Auto-computed by setup.py, source version is always at HEAD
+__version__ = "HEAD"
+
+__all__ = [
+    "task"
+]

--- a/triton_python_model/task/classification.py
+++ b/triton_python_model/task/classification.py
@@ -1,0 +1,153 @@
+import json
+import numpy as np
+from abc import ABC, abstractmethod
+from typing import List, Dict, Tuple
+import triton_python_backend_utils as pb_utils
+import triton_python_model.utils as utils
+
+
+class ClassificationModel(ABC):
+    def __init__(self, input_names: List[str], output_names: List[str]) -> None:
+        """Constructor function
+
+        Args:
+            input_names (List[str]): a list of model input variable names in the model configuration
+            output_names (List[str]): a list of model output variable names in the model configuration
+        """
+        self.task = 'TASK_CLASSIFICATION'
+        self.input_names = input_names
+        self.output_names = output_names
+
+        if len(output_names) != 1:
+            raise ValueError(
+                f'Output has {len(output_names)} elements. There should be 1 output: score outputs')
+
+        self.score_output_config = {
+            "name": output_names[0],
+            "data_type": "TYPE_FP32",
+            "dims": [None]  # [n] n is the number of categories
+        }
+
+    def initialize(self, args: Dict[str, str]) -> None:
+        """`initialize` is called only once when the model is being loaded. Implementing `initialize` function is optional. This function allows the model to initialize any state associated with this model.
+
+        Args:
+            args (Dict[str, str]): Both keys and values are strings. The dictionary keys and values are:
+                * model_config: A JSON string containing the model configuration
+                * model_instance_kind: A string containing model instance kind
+                * model_instance_device_id: A string containing model instance device ID
+                * model_repository: Model repository path
+                * model_version: Model version
+                * model_name: Model name
+        """
+        # Read config file
+        model_config = json.loads(args['model_config'])
+
+        # Validate general model configuration
+        utils.validate_model_config(
+            model_config, self.input_names, self.output_names)
+
+        # Validate model configuration for CLASSIFICATION task
+        score_config = pb_utils.get_output_config_by_name(
+            model_config, name=self.score_output_config["name"])
+        # 1. score must have `label_filename` in the configuration
+        if 'label_filename' not in score_config:
+            raise ValueError(
+                f'Label filename `label_filename` for output {score_config["name"]} is not defined in the model configuration')
+
+        # 2. score output with dim [n] and TYPE_FP32
+        if len(score_config["dims"]) != 1:
+            raise ValueError(
+                f'Dims for output {self.score_output_config["name"]} are {score_config["dims"]}. Its length should be 1.')
+        self.score_output_config["dims"] = score_config["dims"]
+
+        if score_config["data_type"] != self.score_output_config["data_type"]:
+            raise ValueError(
+                f'Data type for output {self.score_output_config["name"]} is {score_config["data_type"]}. It should be {self.score_output_config["data_type"]}')
+        self.score_output_config["data_type"] = pb_utils.triton_string_to_numpy(
+            self.score_output_config["data_type"])
+
+    def execute(self, inference_requests: List[pb_utils.InferenceRequest]) -> List[pb_utils.InferenceResponse]:
+        """`execute` must be implemented in every Python model. `execute` function receives a list of pb_utils.InferenceRequest as the only argument. This function is called when an inference is requested for this model.
+
+        Args:
+            inference_requests (List[pb_utils.InferenceRequest]): A list of Triton Inference Request
+
+        Returns:
+            List[pb_utils.InferenceResponse]: A list of Triton Inference Response. The length of this list must
+            be the same as `inference_requests`
+        """
+        responses = []
+        for req in inference_requests:
+            scores = self.post_process_batch_request(req)
+
+            # Format outputs to build an InferenceResponse
+            scores_tensors = pb_utils.Tensor(
+                self.score_output_config["name"], scores)
+
+            # TODO: should set error field from InferenceResponse constructor to handle errors
+            # https://github.com/triton-inference-server/python_backend#execute
+            # https://github.com/triton-inference-server/python_backend#error-handling
+            res = pb_utils.InferenceResponse(
+                output_tensors=[scores_tensors])
+            responses.append(res)
+
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')
+
+    @abstractmethod
+    def post_process_per_image(self, inputs: Tuple[np.ndarray]) -> np.ndarray:
+        """Post-process classification output in one image of a batch.
+
+        Args:
+            inputs (Tuple[np.ndarray]): Input array for detected objects in one image
+
+        Raises:
+            NotImplementedError: all subclasses must implement this function of per-image post-processing for TASK_CLASSIFICATION task.
+
+        Returns:
+            np.ndarray: classification score array for one image `scores`. The shape of `scores` should be (n,), where n is the number of categories.
+        """
+        raise NotImplementedError(
+            f'Implement per-image inference function for {self.task} model')
+
+    def post_process_batch_request(self, request: pb_utils.InferenceRequest) -> np.ndarray:
+        """Post-process classification outputs in multiple images of a Triton Inference request.
+
+        Args:
+            request (pb_utils.InferenceRequest): a Triton batch inference request
+
+        Returns:
+            np.ndarray: batched classification array `batch_scores`. The shape of batched classification array should be (batch_size, n), where n is the number of categories.
+        """
+        inputs_list = []
+        for name in self.input_names:
+            tensor = pb_utils.get_input_tensor_by_name(request, name)
+            if tensor is None:
+                raise ValueError(
+                    f'Input tensor {name} not found in request {request.request_id()}')
+            # tensor shape: (batch_size, ...)
+            inputs_list.append(tensor.as_numpy())
+
+        scores_list = []
+        for inputs in zip(*inputs_list):
+            # The scores corresponding to all categories in one image of a batch with shape (n,), where n is the number of category.
+            scores = self.post_process_per_image(inputs)
+
+            # shape: (n,)
+            if not(len(scores.shape) == 1 and scores.shape[0] == self.score_output_config["dims"][0]):
+                raise ValueError(
+                    f'Shape of the output score array for each image is {scores.shape} and it should be {self.score_output_config["dims"]}')
+
+            scores_list.append(scores)
+
+        batch_scores = np.asarray(
+            scores_list, dtype=self.score_output_config["data_type"])
+
+        return batch_scores

--- a/triton_python_model/task/detection.py
+++ b/triton_python_model/task/detection.py
@@ -1,0 +1,217 @@
+import json
+import numpy as np
+from abc import ABC, abstractmethod
+from typing import List, Dict, Tuple
+import triton_python_backend_utils as pb_utils
+import triton_python_model.utils as utils
+
+
+class DetectionModel(ABC):
+    def __init__(self, input_names: List[str], output_names: List[str]) -> None:
+        """Constructor function
+
+        Args:
+            input_names (List[str]): a list of model input variable names in the model configuration
+            output_names (List[str]): a list of model output variable names in the model configuration
+        """
+        self.task = 'TASK_DETECTION'
+        self.input_names = input_names
+        self.output_names = output_names
+
+        if len(output_names) != 2:
+            raise ValueError(
+                f'Output has {len(output_names)} elements. There should be 2 outputs: the first is bounding box outputs and the second one is label outputs')
+
+        self.bbox_output_config = {
+            "name": output_names[0],
+            "data_type": "TYPE_FP32",
+            "dims": [-1, 5],
+        }
+        self.label_output_config = {
+            "name": output_names[1],
+            "data_type": "TYPE_STRING",
+            "dims": [-1]
+        }
+
+    def initialize(self, args: Dict[str, str]) -> None:
+        """`initialize` is called only once when the model is being loaded. Implementing `initialize` function is optional. This function allows the model to initialize any state associated with this model.
+
+        Args:
+            args (Dict[str, str]): Both keys and values are strings. The dictionary keys and values are:
+                * model_config: A JSON string containing the model configuration
+                * model_instance_kind: A string containing model instance kind
+                * model_instance_device_id: A string containing model instance device ID
+                * model_repository: Model repository path
+                * model_version: Model version
+                * model_name: Model name
+        """
+        # Read config file
+        model_config = json.loads(args['model_config'])
+
+        # Validate general model configuration
+        utils.validate_model_config(
+            model_config, self.input_names, self.output_names)
+
+        # Validate model configuration for TASK_DETECTION task
+        # 1. The first output: bounding boxes output with dim [-1, 5] and TYPE_FP32
+        bbox_config = pb_utils.get_output_config_by_name(
+            model_config, name=self.bbox_output_config["name"])
+        if bbox_config["dims"] != self.bbox_output_config["dims"]:
+            raise ValueError(
+                f'Dims for output {self.bbox_output_config["name"]} is {bbox_config["dims"]}. They should be {self.bbox_output_config["dims"]}')
+        if bbox_config["data_type"] != self.bbox_output_config["data_type"]:
+            raise ValueError(
+                f'Data type for output {self.bbox_output_config["name"]} is {bbox_config["data_type"]}. It should be {self.bbox_output_config["data_type"]}')
+        self.bbox_output_config["data_type"] = pb_utils.triton_string_to_numpy(
+            self.bbox_output_config["data_type"])
+
+        # 2. The second output: labels output with dim [-1] and TYPE_STRING
+        label_config = pb_utils.get_output_config_by_name(
+            model_config, name=self.label_output_config["name"])
+        if label_config["dims"] != self.label_output_config["dims"]:
+            raise ValueError(
+                f'Dims for output {self.label_output_config["name"]} is {label_config["dims"]}. They should be {self.label_output_config["dims"]}')
+        if label_config["data_type"] != self.label_output_config["data_type"]:
+            raise ValueError(
+                f'Data type for output {self.label_output_config["name"]} is {label_config["data_type"]}. It should be {self.label_output_config["data_type"]}')
+        self.label_output_config["data_type"] = pb_utils.triton_string_to_numpy(
+            self.label_output_config["data_type"])
+
+    def execute(self, inference_requests: List[pb_utils.InferenceRequest]) -> List[pb_utils.InferenceResponse]:
+        """`execute` must be implemented in every Python model. `execute` function receives a list of pb_utils.InferenceRequest as the only argument. This function is called when an inference is requested for this model.
+
+        Args:
+            inference_requests (List[pb_utils.InferenceRequest]): A list of Triton Inference Request
+
+        Returns:
+            List[pb_utils.InferenceResponse]: A list of Triton Inference Response. The length of this list must
+            be the same as `inference_requests`
+        """
+        responses = []
+        for req in inference_requests:
+            bboxes, labels = self.post_process_batch_request(req)
+
+            # Format outputs to build an InferenceResponse
+            bboxes_tensors = pb_utils.Tensor(
+                self.bbox_output_config["name"], bboxes)
+            labels_tensors = pb_utils.Tensor(
+                self.label_output_config["name"], labels)
+
+            # TODO: should set error field from InferenceResponse constructor to handle errors
+            # https://github.com/triton-inference-server/python_backend#execute
+            # https://github.com/triton-inference-server/python_backend#error-handling
+            res = pb_utils.InferenceResponse(
+                output_tensors=[bboxes_tensors, labels_tensors])
+            responses.append(res)
+
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')
+
+    @abstractmethod
+    def post_process_per_image(self, inputs: Tuple[np.ndarray]) -> Tuple[np.ndarray, np.ndarray]:
+        """Post-process objects detected in one image of a batch.
+
+        Args:
+            inputs (Tuple[np.ndarray]): Input array for detected objects in one image
+
+        Raises:
+            NotImplementedError: all subclasses must implement this function of per-image post-processing for TASK_DETECTION task.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: a tuple of bounding box array and label array: (`bboxes`, `labels`).
+                - `bboxes`: the bounding boxes detected in one image of a batch with shape (n,5) or (0,). The bounding box format is [x1, y1, x2, y2, score] in the original image.
+                - `labels`: the labels corresponding to the bounding boxes detected in one image of a batch with shape (n,) or (0,).
+                The length of `bboxes` must be the same as that of `labels`.
+        """
+        raise NotImplementedError(
+            f'Implement per-image inference function for {self.task} model')
+
+    def post_process_batch_request(self, request: pb_utils.InferenceRequest) -> Tuple[np.ndarray, np.ndarray]:
+        """Post-process objects detected in multiple images of a Triton Inference request.
+        The output of all images in a batch must have the same size for Triton to be able to output a numpy array. Therefore, we need to fill with non-meaningful bounding boxes with coords [-1, -1, -1, -1, -1] and label '0'
+
+
+        Args:
+            request (pb_utils.InferenceRequest): a Triton batch inference request
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: a Tuple of batched bounding box array and label array: (`batch_boxes`, `batch_labels`).
+                - `batch_boxes`: the shape of batched bounding box array should be (batch_size, n, 5).
+                - `batch_labels`: the shape of batched label array should be (batch_size, n).
+        """
+        inputs_list = []
+        for name in self.input_names:
+            tensor = pb_utils.get_input_tensor_by_name(request, name)
+            if tensor is None:
+                raise ValueError(
+                    f'Input tensor {name} not found in request {request.request_id()}')
+            # tensor shape: (batch_size, ...)
+            inputs_list.append(tensor.as_numpy())
+
+        max_num_bboxes_in_single_image = 0
+        bboxes_list, labels_list = [], []
+        for inputs in zip(*inputs_list):
+            # `bboxes`: the bounding boxes detected in one image of a batch with shape (n, 5) or (0,)
+            # `labels`: the labels corresponding to the bounding boxes detected in one image of a batch with shape (n,) or (0,).
+            # The length of `bboxes` must be the same as that of `labels`.
+            bboxes, labels = self.post_process_per_image(inputs)
+
+            if bboxes.shape[0] != labels.shape[0]:
+                raise ValueError(
+                    f'The length of the output bounding box array {bboxes.shape} should be the same as that of the output label array {labels.shape} for each image')
+
+            if len(bboxes.shape) == 2:  # shape: (n, 5)  `n` is the number of bounding boxes
+                if bboxes.shape[-1] != self.bbox_output_config["dims"][-1]:
+                    raise ValueError(
+                        f'Shape of the output bounding box array for each image should be either (n, 5) or (0,)')
+            elif len(bboxes.shape) == 1:    # shape: (0,)
+                if bboxes.shape[-1] != 0:
+                    raise ValueError(
+                        f'Shape of the output bounding box array for each image should be either (n, 5) or (0,)')
+            else:
+                raise ValueError(
+                    f'Shape of the output bounding box array for each image should be either (n, 5) or (0,)')
+
+            if len(labels.shape) != 1:  # shape: (n,)
+                raise ValueError(
+                    f'Shape of the output label array for each image should be either (n,) or (0,)')
+
+            max_num_bboxes_in_single_image = max(
+                len(bboxes), max_num_bboxes_in_single_image)
+
+            bboxes_list.append(bboxes)
+            labels_list.append(labels)
+
+        if max_num_bboxes_in_single_image == 0:
+            # When no detected object at all in all images in the batch
+            for idx, _ in enumerate(zip(bboxes_list, labels_list)):
+                num_to_add = 1
+                bboxes_list[idx] = - np.ones(
+                    (num_to_add, self.bbox_output_config["dim"][-1]), dtype=self.bbox_output_config["data_type"])
+                labels_list[idx] = ["0"] * num_to_add
+        else:
+            for idx, (bboxes, labels) in enumerate(zip(bboxes_list, labels_list)):
+                if len(bboxes) < max_num_bboxes_in_single_image:
+                    num_to_add = max_num_bboxes_in_single_image - len(bboxes)
+                    bboxes_to_add = - np.ones(
+                        (num_to_add, self.bbox_output_config["dim"][-1]), dtype=self.bbox_output_config["data_type"])
+                    labels_to_add = ["0"] * num_to_add
+                    if len(bboxes) == 0:
+                        bboxes_list[idx] = bboxes_to_add
+                        labels_list[idx] = labels_to_add
+                    else:
+                        bboxes_list[idx] = np.vstack(bboxes, bboxes_to_add)
+                        labels_list[idx] = labels + labels_to_add
+
+        batch_bboxes = np.asarray(
+            bboxes_list, dtype=self.bbox_output_config["data_type"])
+        batch_labels = np.asarray(
+            labels_list, dtype=self.label_output_config["data_type"])
+
+        return batch_bboxes, batch_labels

--- a/triton_python_model/utils.py
+++ b/triton_python_model/utils.py
@@ -1,0 +1,82 @@
+from typing import Any, List, Dict
+import triton_python_backend_utils as pb_utils
+
+
+def validate_model_config(model_config: Dict[str, Any], input_names: List[str], output_names: List[str]) -> None:
+    """Validate the model configuration based on the input and output variable names.
+
+    Args:
+        model_config (Dict[str, Any]): a JSON string containing the model configuration
+        input_names (List[str]): a list of model input variable names
+        output_names (List[str]): a list of model output variable names
+    """
+    if 'backend' not in model_config:
+        raise ValueError('Backend is not defined in the model configuration')
+    if model_config['backend'] != 'python':
+        raise ValueError(
+            'Backend is not set to python in the model configuration')
+
+    if 'max_batch_size' not in model_config:
+        raise ValueError(
+            'Maximum batch size is not defined in the model configuration')
+    if not isinstance(model_config['max_batch_size'], int):
+        raise TypeError(
+            f'Maximum batch size type {type(model_config["max_batch_size"])} is not int type in the model configuration')
+
+    if 'input' not in model_config:
+        raise ValueError("Input is not defined in the model configuration")
+
+    # Check that the `input_names` is the same as the config input names
+    model_config_input_names = [input_properties["name"]
+                                for input_properties in model_config["input"]]
+    if input_names != model_config_input_names:
+        raise ValueError(
+            f'{input_names} is not consistent with input names {model_config_input_names} in the model configuration')
+
+    input_configs = [pb_utils.get_input_config_by_name(
+        model_config, name) for name in input_names]
+    for (name, cfg) in zip(input_names, input_configs):
+        if cfg is None:
+            raise ValueError(
+                f'Input {name} is not defined in the model configuration')
+        if 'name' not in cfg:
+            raise ValueError(
+                f'Name for input {name} is not defined in the model configuration')
+        if 'dims' not in cfg:
+            raise ValueError(
+                f'Dims for input {name} are not defined in the model configuration')
+        if not isinstance(cfg['dims'], list):
+            raise TypeError(
+                f'Dims for input {name} type {type(cfg["dims"])} are not list type in the model configuration')
+        if 'data_type' not in cfg:
+            raise ValueError(
+                f'Data type for input {name} is not defined in the model configuration')
+
+    if 'output' not in model_config:
+        raise ValueError("Output is not defined in the model configuration")
+
+    # Check that the `output_names` is the same as the config output names
+    model_config_output_names = [
+        output_properties["name"] for output_properties in model_config["output"]]
+    if output_names != model_config_output_names:
+        raise ValueError(
+            f'{output_names} is not consistent with output names {model_config_output_names} in the model configuration')
+
+    output_configs = [pb_utils.get_output_config_by_name(
+        model_config, name) for name in output_names]
+    for (name, cfg) in zip(output_names, output_configs):
+        if cfg is None:
+            raise ValueError(
+                f'Output {name} is not defined in the model configuration')
+        if 'name' not in cfg:
+            raise ValueError(
+                f'Name for output {name} is not defined in the model configuration')
+        if 'dims' not in cfg:
+            raise ValueError(
+                f'Dims for output {name} are not defined in the model configuration')
+        if not isinstance(cfg['dims'], list):
+            raise TypeError(
+                f'Dims for output {name} type {type(cfg["dims"])} are not list type in the model configuration')
+        if 'data_type' not in cfg:
+            raise ValueError(
+                f'Data type for output {name} is not defined in the model configuration')


### PR DESCRIPTION
Because

we want to streamline the Triton python model design when the model is labelled with a specific Computer Vision task, such as `TASK_CLASSIFICATION` and `TASK_DETECTION`.

This commit

- update release-please workflow
- add `triton-python-model` package in our maintained conda environment
  - define `ClassificationModel` for `TASK_CLASSIFICATION`;
  - define `DetectionModel` for `TASK_DETECTION`;
- update `README.md`

When creating a model labelled with a specific task deployed in vdp project, a user can define a post-processing python model inherited from the corresponding task class defined in the `trition-python-model`.
